### PR TITLE
fix(bootstrap): remove double quotes

### DIFF
--- a/aws/tools/terraform-init
+++ b/aws/tools/terraform-init
@@ -6,12 +6,12 @@ source ../../../tools/aws-envs.sh
 pushd $TERRAFORM_BACKEND_DIR > /dev/null
 # Bucket for storing state files, DynamoDB table for protecting concurrent state file modifications and KMS key arn for
 # encrypting the state file at rest
-STATE_BUCKET=$(terraform output state_bucket)
-DYNAMODB_TABLE=$(terraform output dynamodb_table)
-KMS_KEY_ID=$(terraform output kms_key_id)
+STATE_BUCKET=$(terraform output state_bucket | tr -d '"')
+DYNAMODB_TABLE=$(terraform output dynamodb_table | tr -d '"')
+KMS_KEY_ID=$(terraform output kms_key_id | tr -d '"')
 
 # Make KMS key for SOPS available
-export SOPS_KMS_ARN=$(terraform output sops_kms_key_arn)
+export SOPS_KMS_ARN=$(terraform output sops_kms_key_arn | tr -d '"')
 popd > /dev/null
 
 # Define the value of `state_file` input variable, used in terraform_remote_state data sources


### PR DESCRIPTION
Terraform v0.14+ returns output within double quotes.
This breaks the script that sets up Terraform to use the
bootstrapped state.

https://github.com/hashicorp/terraform/issues/26831

This commit uses `tr -d` to remove the quotes. Running Terraform
with `output -json` is recommended for automation, but would
require additional dependencies for processing JSON.